### PR TITLE
更新CI配置：升级Python版本并添加发布条件

### DIFF
--- a/.github/workflows/build-pr.yml
+++ b/.github/workflows/build-pr.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-            - "3.11"
+            - "3.12"
     name: Windows Python ${{ matrix.python_version }}
     steps:
       - uses: actions/checkout@v2
@@ -46,6 +46,7 @@ jobs:
                   -i ./pypvz.ico
 
       - name: Release the version built by pyinstaller
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -77,6 +78,7 @@ jobs:
                   pypvz.py
 
       - name: Release the version built by nuitka
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true
@@ -91,7 +93,7 @@ jobs:
       fail-fast: false
       matrix:
         python_version:
-            - "3.11"
+            - "3.12"
     name: Ubuntu Python ${{ matrix.python_version }}
     steps:
       - name: 🛎️ Checkout
@@ -131,6 +133,7 @@ jobs:
                 pypvz.py
 
       - name: Release the version built by nuitka
+        if: github.event.pull_request.head.repo.full_name == github.repository
         uses: ncipollo/release-action@v1
         with:
           allowUpdates: true


### PR DESCRIPTION
* 将CI工作流的Python版本从3.11升级到3.12
* 为所有发布步骤添加仓库条件检测，避免在fork仓库的PR中触发发布